### PR TITLE
Update Loki image version to 3.4.1 in docker-compose configuration

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -29,7 +29,7 @@ services:
 
 
   loki:
-    image: grafana/loki:3.1.2
+    image: grafana/loki:3.4.1
     container_name: loki
     restart: always
     ports:


### PR DESCRIPTION
This pull request includes an update to the `docker-compose.observability.yml` file to ensure the use of the latest version of the `loki` service.

* [`docker-compose.observability.yml`](diffhunk://#diff-9d71f3a38bc0375f7f6be5e1ba283a594c846ddab6d546b495a915e73d269f56L32-R32): Updated the `loki` image from version `3.1.2` to `3.4.1`.