### PR TITLE
build(dependencies): update System.Text.Json and OpenTelemetry packages

### DIFF
--- a/src/Demo.Gateway.Email/3.Gateway.Email.csproj
+++ b/src/Demo.Gateway.Email/3.Gateway.Email.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="System.Text.Json" Version="9.0.1" /> <!-- To fix vulnerability -->
+    <PackageReference Include="System.Text.Json" Version="9.0.4" /> <!-- To fix vulnerability -->
 
     <!-- Storage -->
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />

--- a/src/Demo.Gateway.SMS/4.Gateway.SMS.csproj
+++ b/src/Demo.Gateway.SMS/4.Gateway.SMS.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="System.Text.Json" Version="9.0.1" /> <!-- To fix vulnerability -->
+    <PackageReference Include="System.Text.Json" Version="9.0.4" /> <!-- To fix vulnerability -->
 
     <!-- Trace -->
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />

--- a/src/Demo.Shared/Demo.BuildingBlocks.Observability/2.Observability.csproj
+++ b/src/Demo.Shared/Demo.BuildingBlocks.Observability/2.Observability.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.12.0" />
     <PackageReference Include="Pyroscope.OpenTelemetry" Version="0.2.0" />
     <PackageReference Include="Pyroscope" Version="0.9.4" />


### PR DESCRIPTION
- Updated System.Text.Json to version 9.0.4 to address vulnerability.
- Updated OpenTelemetry.Exporter.OpenTelemetryProtocol to version 1.12.0.